### PR TITLE
Added info section when promoting application

### DIFF
--- a/tutorials/install-jx-on-gke/lesson.md
+++ b/tutorials/install-jx-on-gke/lesson.md
@@ -114,6 +114,7 @@ production.
 ```bash
 cd cloudshell-tutorial
 ```
+_If you have 2FA enabled on youtr GitHub account, then you may need to use an api token as your password when prompted._
 
 ```bash
 jx promote cloudshell-tutorial --version 0.0.1 --env production

--- a/tutorials/install-jx-on-gke/lesson.md
+++ b/tutorials/install-jx-on-gke/lesson.md
@@ -114,7 +114,7 @@ production.
 ```bash
 cd cloudshell-tutorial
 ```
-_If you have 2FA enabled on youtr GitHub account, then you may need to use an api token as your password when prompted._
+_If you have 2FA enabled on your GitHub account, then you may need to use an api token as your password when prompted._
 
 ```bash
 jx promote cloudshell-tutorial --version 0.0.1 --env production


### PR DESCRIPTION
If you have 2FA enabled and the git repo has been cloned over https then the normal password flow fails as it's unable to prompt for the 2FA device/code. However, if you use an API token then 2FA is not required.